### PR TITLE
Improve raven.js integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-sentry",
   "description": "Gatsby plugin to add Sentry error tracking to your site.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Jason Stallings <jason.stallin.gs>",
   "repository": {
     "type": "git",

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,13 +1,13 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
-const SentryCdn = ({ dsn, version }) =>
-  dsn !== undefined && (
+const SentryCdn = ({ dsn, version = '3.21.0' }) =>
+  dsn ? (
     <script
       src={`https://cdn.ravenjs.com/${version}/raven.min.js`}
       crossOrigin="anonymous"
     />
-  );
+  ) : null;
 
 SentryCdn.propTypes = {
   // Sentry public DSN.
@@ -16,25 +16,23 @@ SentryCdn.propTypes = {
   // If omitted, Raven.js will be excluded from the build, and Sentry will be disabled.
   dsn: PropTypes.string,
   // The version of Raven.js to load.
-  version: PropTypes.string
+  version: PropTypes.string,
 };
 
 SentryCdn.defaultProps = {
   dsn: null,
-  version: "3.21.0"
+  version: '3.21.0',
 };
 
 const SentryInstall = ({ dsn, config = {} }) => {
-  return (
-    dsn !== undefined && (
-      <script
-        type="text/javascript"
-        dangerouslySetInnerHTML={{
-          __html: `Raven.config('${dsn}', ${JSON.stringify(config)}).install();`
-        }}
-      />
-    )
-  );
+  return dsn ? (
+    <script
+      type="text/javascript"
+      dangerouslySetInnerHTML={{
+        __html: `Raven.config('${dsn}', ${JSON.stringify(config)}).install();`,
+      }}
+    />
+  ) : null;
 };
 
 SentryInstall.propTypes = {
@@ -45,17 +43,21 @@ SentryInstall.propTypes = {
   dsn: PropTypes.string,
   // The Raven.js configuration object.
   // See: https://docs.sentry.io/clients/javascript/config/.
-  config: PropTypes.string
+  config: PropTypes.object,
 };
 
 SentryCdn.defaultProps = {
   dsn: null,
-  config: {}
+  config: {},
 };
 
 exports.onRenderBody = ({ setHeadComponents }, { version, dsn, config }) => {
   return setHeadComponents([
     <SentryCdn dsn={dsn} version={version} key="gatsby-plugin-sentry-cdn" />,
-    <SentryInstall dsn={dsn} config={config} key="gatsby-plugin-sentry-install" />
+    <SentryInstall
+      dsn={dsn}
+      config={config}
+      key="gatsby-plugin-sentry-install"
+    />,
   ]);
 };

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 const SentryCdn = ({ dsn, version }) =>
   dsn !== undefined && (

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,25 +1,60 @@
-import React from 'react';
+import React from "react";
 
-const SentryCdn = ({ version }) => (
-  <script src={`https://cdn.ravenjs.com/${version}/raven.min.js`} crossOrigin="anonymous" />
-);
+const SentryCdn = ({ dsn, version }) =>
+  dsn !== undefined && (
+    <script
+      src={`https://cdn.ravenjs.com/${version}/raven.min.js`}
+      crossOrigin="anonymous"
+    />
+  );
 
-SentryCdn.defaultProps = {
-  version: '3.19.1',
+SentryCdn.propTypes = {
+  // Sentry public DSN.
+  // (obtained from https://docs.sentry.io/clients/javascript/#configuring-the-client)
+  //
+  // If omitted, Raven.js will be excluded from the build, and Sentry will be disabled.
+  dsn: PropTypes.string,
+  // The version of Raven.js to load.
+  version: PropTypes.string
 };
 
-const SentryInstall = ({ dsn }) => (
-  <script
-    type="text/javascript"
-    dangerouslySetInnerHTML={{
-      __html: `Raven.config('${dsn}', { environment: '${process.env.NODE_ENV}' }).install();`,
-    }}
-  />
-);
+SentryCdn.defaultProps = {
+  dsn: null,
+  version: "3.21.0"
+};
 
-exports.onRenderBody = ({ setHeadComponents }, { version, dsn }) => {
+const SentryInstall = ({ dsn, config = {} }) => {
+  return (
+    dsn !== undefined && (
+      <script
+        type="text/javascript"
+        dangerouslySetInnerHTML={{
+          __html: `Raven.config('${dsn}', ${JSON.stringify(config)}).install();`
+        }}
+      />
+    )
+  );
+};
+
+SentryInstall.propTypes = {
+  // Sentry public DSN.
+  // (obtained from https://docs.sentry.io/clients/javascript/#configuring-the-client)
+  //
+  // If omitted, Raven.js will be excluded from the build, and Sentry will be disabled.
+  dsn: PropTypes.string,
+  // The Raven.js configuration object.
+  // See: https://docs.sentry.io/clients/javascript/config/.
+  config: PropTypes.string
+};
+
+SentryCdn.defaultProps = {
+  dsn: null,
+  config: {}
+};
+
+exports.onRenderBody = ({ setHeadComponents }, { version, dsn, config }) => {
   return setHeadComponents([
-    <SentryCdn version={version} key="gatsby-plugin-sentry-cdn" />,
-    <SentryInstall dsn={dsn} key="gatsby-plugin-sentry-install" />,
+    <SentryCdn dsn={dsn} version={version} key="gatsby-plugin-sentry-cdn" />,
+    <SentryInstall dsn={dsn} config={config} key="gatsby-plugin-sentry-install" />
   ]);
 };


### PR DESCRIPTION
Hey @octalmage,

I don't know if your repo is the "definitive" gatsby-sentry integration. However, I thought I'd try consolidating my customizations into your version since you've got the npm namespace 😸 

These might be considered breaking changes, so it might make sense to bump the version number of npm appropriately.

Summary of my changes:

* Upgrade default version of raven.js
* Pass through full raven.js config object
* Disable integration if DSN is undefined
* Add documentation

Thanks!