### PR TITLE
feat(dev): only add sentry plugin if node env is production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-sentry",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-sentry",
   "description": "Gatsby plugin to add Sentry error tracking to your site.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Jason Stallings <jason.stallin.gs>",
   "repository": {
     "type": "git",

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -52,12 +52,16 @@ SentryCdn.defaultProps = {
 };
 
 exports.onRenderBody = ({ setHeadComponents }, { version, dsn, config }) => {
-  return setHeadComponents([
-    <SentryCdn dsn={dsn} version={version} key="gatsby-plugin-sentry-cdn" />,
-    <SentryInstall
-      dsn={dsn}
-      config={config}
-      key="gatsby-plugin-sentry-install"
-    />,
-  ]);
+  if (process.env.NODE_ENV === `production`) {
+    return setHeadComponents([
+      <SentryCdn dsn={dsn} version={version} key="gatsby-plugin-sentry-cdn" />,
+      <SentryInstall
+        dsn={dsn}
+        config={config}
+        key="gatsby-plugin-sentry-install"
+      />,
+    ]);
+  }
+  
+  return null;
 };


### PR DESCRIPTION
I added a check for `process.env.NODE_ENV === 'production'`. If the check fails the Sentry components will not be added.

I think most developers don't need the sentry errors logged if they work locally.

Resolves #3.