### PR TITLE
Only load Raven in production.

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,8 +1,10 @@
-exports.onClientEntry = (_, pluginParams) => {
-    require.ensure(['raven-js'], require => {
-        const Raven = require('raven-js');
+exports.onClientEntry = function(_, pluginParams) {
+  if (process.env.NODE_ENV === 'production') {
+    require.ensure(['raven-js'], function(require) {
+      const Raven = require('raven-js');
 
-        if (!Raven.isSetup()) Raven.config(pluginParams.dsn, pluginParams.config).install();
-        window.Raven = Raven;
+      if (!Raven.isSetup()) Raven.config(pluginParams.dsn, pluginParams.config).install();
+      window.Raven = Raven;
     });
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-sentry",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-sentry",
   "description": "Gatsby plugin to add Sentry error tracking to your site.",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "author": "Jason Stallings <jason.stallin.gs>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
On my site after #9 I was getting the following error: 

```
TypeError: Cannot read property 'call' of undefined
```

This error only happened in development, and I believe it has something to do with hot reloading. I saw people recommend loading the dependency statically in development to resolve this, but we don't even need this for development. 

Thoughts @Thien42 and @abumalick? 