### PR TITLE
consider using latest SDK, Enabled based on environments from config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Gatsby plugin to add Sentry error tracking to your site.
 Learn more about Sentry [here](https://sentry.io).
 
 ## Install
+
 `npm install --save gatsby-plugin-sentry`
 
 ## How to use
@@ -13,16 +14,45 @@ Learn more about Sentry [here](https://sentry.io).
 // In your gatsby-config.js
 plugins: [
   {
-    resolve: 'gatsby-plugin-sentry',
+    resolve: "gatsby-plugin-sentry",
     options: {
-      dsn: 'YOUR_SENTRY_DSN_URL',
+      dsn: "YOUR_SENTRY_DSN_URL",
       // Optional settings, see https://docs.sentry.io/clients/node/config/#optional-settings
-      config: {
-        environment: process.env.NODE_ENV,
-        // if shouldSendCallback returns false, sentry won't log error, https://docs.sentry.io/clients/javascript/config/#shouldSendCallback
-        shouldSendCallback: () => ['production', 'stage'].indexOf(process.env.NODE_ENV) !== -1
-      }
-    },
-  },
-]
+      environment: process.env.NODE_ENV,
+      enabled: (() => ["production", "stage"].indexOf(process.env.NODE_ENV) !== -1)()
+    }
+  }
+];
+```
+
+Now `Sentry` is availble in global window object. so you can use it in `react 16` like:
+
+```javascript
+export default class ErrorBoundary extends React.Component {
+  
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ error });
+    Sentry.configureScope((scope) => {
+      Object.keys(errorInfo).forEach(key => {
+        scope.setExtra(key, errorInfo[key]);
+      });
+    });
+    Sentry.captureException(error);
+  }
+
+  render() {
+    if (this.state.error) {
+      // render fallback UI
+      return <h1>Something went wrong!</h1>;
+    } else {
+      // when there's not an error, render children untouched
+      return this.props.children;
+    }
+  }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ plugins: [
       dsn: 'YOUR_SENTRY_DSN_URL',
       // Optional settings, see https://docs.sentry.io/clients/node/config/#optional-settings
       config: {
-        environment: 'staging'
+        environment: process.env.NODE_ENV,
+        // if shouldSendCallback returns false, sentry won't log error, https://docs.sentry.io/clients/javascript/config/#shouldSendCallback
+        shouldSendCallback: () => ['production', 'stage'].indexOf(process.env.NODE_ENV) !== -1
       }
     },
   },

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,10 +1,8 @@
 exports.onClientEntry = function(_, pluginParams) {
-  if (process.env.NODE_ENV === 'production') {
-    require.ensure(['raven-js'], function(require) {
-      const Raven = require('raven-js');
+  require.ensure(['raven-js'], function(require) {
+    const Raven = require('raven-js');
 
-      if (!Raven.isSetup()) Raven.config(pluginParams.dsn, pluginParams.config).install();
-      window.Raven = Raven;
-    });
-  }
+    if (!Raven.isSetup()) Raven.config(pluginParams.dsn, pluginParams.config).install();
+    window.Raven = Raven;
+  });
 };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,8 +1,7 @@
 exports.onClientEntry = function(_, pluginParams) {
-  require.ensure(['raven-js'], function(require) {
-    const Raven = require('raven-js');
-
-    if (!Raven.isSetup()) Raven.config(pluginParams.dsn, pluginParams.config).install();
-    window.Raven = Raven;
+  require.ensure(['@sentry/browser'], function(require) {
+    const Sentry = require('@sentry/browser');
+    Sentry.init(pluginParams);
+    window.Sentry = Sentry;
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,57 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "raven-js": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.26.3.tgz",
-      "integrity": "sha512-VPAsPfK73A9VPcJx5X/kt0GxOqUGpGDM8vdzsYNQXMhYemyZGiW1JX1AI+f4jxm37Apijj6VVtCyJcYFz3ocSQ=="
+    "@sentry/browser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-4.1.1.tgz",
+      "integrity": "sha512-rmkGlTh0AL3Jf0DvF3BluChIyzPkkYpNgIwEHjxTUiLp6BQdgwakZuzBqSPJrEs+jMsKMoesOuJ/fAAG0K7+Ew==",
+      "requires": {
+        "@sentry/core": "4.1.1",
+        "@sentry/types": "4.1.0",
+        "@sentry/utils": "4.1.1"
+      }
+    },
+    "@sentry/core": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-4.1.1.tgz",
+      "integrity": "sha512-QJExTxZ1ZA5P/To5gOwd3sowukXW0N/Q9nfu8biRDNa+YURn6ElLjO0fD6eIBqX1f3npo/kTiWZwFBc7LXEzSg==",
+      "requires": {
+        "@sentry/hub": "4.1.1",
+        "@sentry/minimal": "4.1.1",
+        "@sentry/types": "4.1.0",
+        "@sentry/utils": "4.1.1"
+      }
+    },
+    "@sentry/hub": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-4.1.1.tgz",
+      "integrity": "sha512-VmcZOgcbFjJzK1oQNwcFP/wgfoWQr24dFv1C0uwdXldNXx3mwyUVkomvklBHz90HwiahsI/gCc+ZmbC3ECQk2Q==",
+      "requires": {
+        "@sentry/types": "4.1.0",
+        "@sentry/utils": "4.1.1"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-4.1.1.tgz",
+      "integrity": "sha512-xRKWA46OGnZinJyTljDUel53emPP9mb/XNi/kF6SBaVDOUXl7HAB8kP7Bn7eLBwOanxN8PbYoAzh/lIQXWTmDg==",
+      "requires": {
+        "@sentry/hub": "4.1.1",
+        "@sentry/types": "4.1.0"
+      }
+    },
+    "@sentry/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-KY7B9wYs1NACHlYzG4OuP6k4uQJkyDPJppftjj3NJYShfwdDTO1I2Swkhhb5dJMEMMMpBJGxXmiqZ2mX5ErISQ=="
+    },
+    "@sentry/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-XMvGqAWATBrRkOF0lkt0Ij8of2mRmp4WeFTUAgiKzCekxfUBLBaTb4wTaFXz1cnnnjVTwcAq72qBRMhHwQ0IIg==",
+      "requires": {
+        "@sentry/types": "4.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "raven-js": "latest"
+    "@sentry/browser": "latest"
   }
 }


### PR DESCRIPTION
Hi, 

Thank you for your Plugin. I added a refinement to the config, it's very likely that NODE_ENV is modified or we want to log error for different environments as well. for instance, what we have 5 different environments and expect Development, we'd like to log errors for others as our codebase is pretty big and testing before releasing to prod is very very likely. 

Therefore, with this PR, it's possible to add environment into config file where it's under control and it's not hard coded in plugin. 

Thanks, 