### PR TITLE
Replace require.ensure() with import()

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,5 @@
 exports.onClientEntry = function(_, pluginParams) {
-  require.ensure(['@sentry/browser'], function(require) {
-    const Sentry = require('@sentry/browser');
+  import('@sentry/browser').then((Sentry) => {
     Sentry.init(pluginParams);
     window.Sentry = Sentry;
   });


### PR DESCRIPTION
The recommended way to split code in Gatsby v2 is by using `import()`.
https://www.gatsbyjs.org/docs/how-code-splitting-works/