### PR TITLE
fix: use semver in package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "@sentry/browser": "latest"
+    "@sentry/browser": "*"
   }
 }


### PR DESCRIPTION
I had a problem in my project that uses yarn workspaces, in that I had multiple workspaces depending on `@sentry/browser`, but they wouldn't dedupe and an old version was persistently brought in via gatsby-plugin-sentry. I tracked it down to the dependency in gatsby-plugin-sentry being declared as `latest`, and on switching it to `*` the issue was resolved.

I assume that because `latest` isn't a semver, and is instead a registry tag, it doesn't resolve properly in the dependency resolution of yarn.